### PR TITLE
added initialization of member actionKey in constructor of class Context

### DIFF
--- a/src/main/java/rcms/utilities/daqexpert/reasoning/base/Context.java
+++ b/src/main/java/rcms/utilities/daqexpert/reasoning/base/Context.java
@@ -28,6 +28,7 @@ public class Context implements Serializable {
 
 	public Context() {
 		this.context = new HashMap<>();
+		this.actionKey = new HashSet<>();
 	}
 
 	public void register(String key, Object object) {


### PR DESCRIPTION
as discussed

Useful when running tests, one would otherwise need to call `clearContext()` after object construction.