### PR TITLE
fc2 require corrupted fed

### DIFF
--- a/src/main/java/rcms/utilities/daqexpert/reasoning/logic/failures/FlowchartCase2.java
+++ b/src/main/java/rcms/utilities/daqexpert/reasoning/logic/failures/FlowchartCase2.java
@@ -63,7 +63,6 @@ public class FlowchartCase2 extends KnownFailure {
 				
 					i++;
 					context.register("RU", ru.getHostname());
-					result = true;
 
 				}
 
@@ -85,6 +84,8 @@ public class FlowchartCase2 extends KnownFailure {
 							context.register("TTCP", ttcpName);
 							context.register("SUBSYSTEM", subsystemName);
 							i++;
+
+							result = true;
 						}
 					}
 				}

--- a/src/main/java/rcms/utilities/daqexpert/reasoning/logic/failures/FlowchartCase2.java
+++ b/src/main/java/rcms/utilities/daqexpert/reasoning/logic/failures/FlowchartCase2.java
@@ -1,5 +1,6 @@
 package rcms.utilities.daqexpert.reasoning.logic.failures;
 
+import java.util.List;
 import java.util.Map;
 
 import org.apache.log4j.Logger;
@@ -52,14 +53,14 @@ public class FlowchartCase2 extends KnownFailure {
 
 			if (ERROR_STATE.equalsIgnoreCase(l0state) && ERROR_STATE.equalsIgnoreCase(daqstate)) {
 
-				for (FEDBuilder fb : daq.getFedBuilders()) {
-					RU ru = fb.getRu();
-					if (ru.getStateName().equalsIgnoreCase("Failed")) {
+				List<RU> failedRus = daq.getRusInState("Failed");
 
-						i++;
-						context.register("RU", ru.getHostname());
-						result = true;
-					}
+				for (RU ru : failedRus) {
+				
+					i++;
+					context.register("RU", ru.getHostname());
+					result = true;
+
 				}
 
 				for (FED fed : daq.getFeds()) {

--- a/src/main/java/rcms/utilities/daqexpert/reasoning/logic/failures/FlowchartCase2.java
+++ b/src/main/java/rcms/utilities/daqexpert/reasoning/logic/failures/FlowchartCase2.java
@@ -55,6 +55,10 @@ public class FlowchartCase2 extends KnownFailure {
 
 				List<RU> failedRus = daq.getRusInState("Failed");
 
+				if (failedRus.isEmpty()) {
+					return false;
+				}
+
 				for (RU ru : failedRus) {
 				
 					i++;


### PR DESCRIPTION
now requiring in FC2 that there is both
- at least one RU in failed state
- at least one FED is marked as having sent corrupted data

(previously FC2 fired even if there was no FED data corruption)

needs cmsdaq/DAQAggregator/pull/90 to compile
