### PR TITLE
require syncloss instead of RunBlocked in FlowchartCase1

### DIFF
--- a/src/main/java/rcms/utilities/daqexpert/reasoning/logic/failures/FlowchartCase1.java
+++ b/src/main/java/rcms/utilities/daqexpert/reasoning/logic/failures/FlowchartCase1.java
@@ -148,7 +148,7 @@ public class FlowchartCase1 extends KnownFailure {
 			} // RU in syncloss state found
 
 			return true;
-		} // if runblocked state
+		}
 	}
 
 }

--- a/src/main/java/rcms/utilities/daqexpert/reasoning/logic/failures/FlowchartCase1.java
+++ b/src/main/java/rcms/utilities/daqexpert/reasoning/logic/failures/FlowchartCase1.java
@@ -73,7 +73,13 @@ public class FlowchartCase1 extends KnownFailure {
 
 		String daqstate = daq.getDaqState();
 		// note that the l0state may e.g. be 'Error'
-		if (RUNBLOCKED_STATE.equalsIgnoreCase(daqstate)) {
+
+		// we do not require anymore that DAQ is in 'RunBlocked' state for the moment
+		// since sometimes the state is not propagated properly
+		//
+		// SyncLoss state of the RU is a strong enough signal that we have
+		// the problem this class should detect
+		{
 
 			// for the moment, just find the first RU in SyncLoss
 			RU syncLossRU = null;
@@ -87,9 +93,9 @@ public class FlowchartCase1 extends KnownFailure {
 			}
 
 			if (syncLossRU == null) {
-				// no RU in syncloss found, we don't know FED, TTCP and
-				// SUBSYSTEM
-				setContextValues("(RU not found)");
+
+				// we insist that there is at least one RU in SyncLoss state
+				return false;
 
 			} else {
 
@@ -143,8 +149,6 @@ public class FlowchartCase1 extends KnownFailure {
 
 			return true;
 		} // if runblocked state
-
-		return false;
 	}
 
 }

--- a/src/test/java/rcms/utilities/daqexpert/reasoning/logic/failures/FlowchartCase6Test.java
+++ b/src/test/java/rcms/utilities/daqexpert/reasoning/logic/failures/FlowchartCase6Test.java
@@ -20,8 +20,8 @@ public class FlowchartCase6Test extends FlowchartCaseTestBase {
 		// GMT: Sat, 26 Nov 2016 06:21:35 GMT
 		DAQ snapshot = getSnapshot("1480141295312.smile");
 
-
-		assertEqualsAndUpdateResults(false, fc1,snapshot);
+		// there is actually one RU in syncloss
+		assertEqualsAndUpdateResults(true, fc1,snapshot);
 		assertEqualsAndUpdateResults(false, fc2,snapshot);
 		assertEqualsAndUpdateResults(false, fc3,snapshot);
 		


### PR DESCRIPTION
As discussed with @mommsen and as pointed out in https://github.com/cmsdaq/DAQExpert/issues/76#issuecomment-309432279 this pull request proposes to drop the requirement for DAQ state `RunBlocked` in `FlowchartCase1` and require instead that at least one RU is in `SyncLoss` state.

Had to modify the expected result for FlowchartCase1 in FlowchartCase6Test (becase the test case in question actually involves a RU in `SyncLoss`).

`mvn test` gives `Tests run: 64, Failures: 0, Errors: 0, Skipped: 4`
`mvn integration-test` gives `Tests run: 9, Failures: 0, Errors: 0, Skipped: 1`