### PR TITLE
pom.xml file fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,11 +52,6 @@
 
 
 		<dependency>
-			<groupId>org.apache.httpcomponents</groupId>
-			<artifactId>httpclient</artifactId>
-			<version>4.1.1</version>
-		</dependency>
-		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-core</artifactId>
 			<version>2.7.4</version>

--- a/pom.xml
+++ b/pom.xml
@@ -217,6 +217,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-war-plugin</artifactId>
+                                <version>3.1.0</version>
 				<configuration>
 					<webXml>src/main/webapp/WEB-INF/web.xml</webXml>
 					<archive>


### PR DESCRIPTION
When trying to build, my maven complained about two issues which this pull request fixes:

* the dependency `org.apache.httpcomponents` was specified more than once
* there was no version number for `maven-war-plugin`