### PR TITLE
added strings for LHC modes

### DIFF
--- a/src/main/java/rcms/utilities/daqexpert/reasoning/base/enums/LHCBeamMode.java
+++ b/src/main/java/rcms/utilities/daqexpert/reasoning/base/enums/LHCBeamMode.java
@@ -2,26 +2,32 @@ package rcms.utilities.daqexpert.reasoning.base.enums;
 
 public enum LHCBeamMode {
 
-	INJECTION_PROBE_BEAM(""),
-	INJECTION_SETUP_BEAM(""),
-	INJECTION_PHYSICS_BEAM(""),
-	PREPARE_RAMP(""),
-	RAMP(""),
-	FLAT_TOP(""),
-	SQUEEZE(""),
-	ADJUST(""),
+	/* string constants were taken from the LHC beam conditions SQL table.
+	   BEAM_DUMP_WARNING was not found in this table, the value below
+	   is the expected string.
+	*/
+
+	INJECTION_PROBE_BEAM("INJECTION PROBE BEAM"),
+	INJECTION_SETUP_BEAM("INJECTION SETUP BEAM"),
+	INJECTION_PHYSICS_BEAM("INJECTION PHYSICS BEAM"),
+	PREPARE_RAMP("PREPARE RAMP"),
+	RAMP("RAMP"),
+	FLAT_TOP("FLAT TOP"),
+	SQUEEZE("SQUEEZE"),
+	ADJUST("ADJUST"),
 	STABLE_BEAMS("STABLE BEAMS"),
 
-	ABORT(""),
-	SETUP(""),
-	INJECT_AND_DUMP(""),
-	CIRCULATE_AND_DUMP(""),
-	RAMP_DOWN(""),
-	RECOVER(""),
-	CYCLING(""),
-	BEAM_DUMP(""),
-	UNSTABLE_BEAMS(""),
-	BEAM_DUMP_WARNING(""),
+	ABORT("ABORT"),
+	SETUP("SETUP"),
+	INJECT_AND_DUMP("INJECT AND DUMP"),
+	CIRCULATE_AND_DUMP("CIRCULATE AND DUMP"),
+	RAMP_DOWN("RAMP DOWN"),
+	RECOVER("RECOVERY"),  // note the disagreement between Java symbol and string
+	CYCLING("CYCLING"),
+	BEAM_DUMP("BEAM DUMP"),
+	UNSTABLE_BEAMS("UNSTABLE BEAMS"),
+	BEAM_DUMP_WARNING("BEAM_DUMP_WARNING"), // this mode was not found in beam modes history
+
 	UNKNOWN("unknown");
 	
 	private final String code;

--- a/src/main/java/rcms/utilities/daqexpert/reasoning/base/enums/LHCBeamMode.java
+++ b/src/main/java/rcms/utilities/daqexpert/reasoning/base/enums/LHCBeamMode.java
@@ -28,6 +28,8 @@ public enum LHCBeamMode {
 	UNSTABLE_BEAMS("UNSTABLE BEAMS"),
 	BEAM_DUMP_WARNING("BEAM_DUMP_WARNING"), // this mode was not found in beam modes history
 
+	NO_BEAM("NO BEAM"),
+
 	UNKNOWN("unknown");
 	
 	private final String code;

--- a/src/main/java/rcms/utilities/daqexpert/reasoning/base/enums/LHCBeamMode.java
+++ b/src/main/java/rcms/utilities/daqexpert/reasoning/base/enums/LHCBeamMode.java
@@ -42,10 +42,23 @@ public enum LHCBeamMode {
 		return code;
 	}
 
+	/** method to convert a string describing an LHC machine
+	 *  mode into an LHCBeamMode enum.
+	 *
+	 * @return the LHCBeamMode value corresponding to code
+	 *  or UNKNOWN if not found.
+	 */
 	public static LHCBeamMode getModeByCode(String code) {
-		if (code.equals(STABLE_BEAMS.getCode())) {
-			return LHCBeamMode.STABLE_BEAMS;
-		} else
-			return LHCBeamMode.UNKNOWN;
+
+		// note that some beam mode stirngs have spaces in them
+		// so we can't use LHCBeamMode.valueOf(code)
+		for (LHCBeamMode mode : LHCBeamMode.values()) {
+			if (code.equals(mode.getCode())) {
+				return mode;
+			}
+		}
+
+		// no matching string found
+		return LHCBeamMode.UNKNOWN;
 	}
 }

--- a/src/test/java/rcms/utilities/daqexpert/reasoning/logic/basic/BeamActiveTest.java
+++ b/src/test/java/rcms/utilities/daqexpert/reasoning/logic/basic/BeamActiveTest.java
@@ -1,0 +1,61 @@
+package rcms.utilities.daqexpert.reasoning.logic.basic;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import org.junit.Test;
+import static org.junit.Assert.*;
+import rcms.utilities.daqaggregator.data.DAQ;
+import rcms.utilities.daqexpert.reasoning.base.enums.LHCBeamMode;
+
+/**
+ *
+ * @author holzner
+ */
+public class BeamActiveTest
+{
+	/**
+	 * Test of satisfied method, of class BeamActive.
+	 */
+	@Test
+	public void test01()
+	{
+		DAQ snapshot = new DAQ();
+
+		// modes where the BeamActive module should be satisfied
+		Set<LHCBeamMode> activeModeSet = new HashSet<LHCBeamMode>(Arrays.asList(
+		 new LHCBeamMode[] {
+			LHCBeamMode.INJECTION_PROBE_BEAM,
+			LHCBeamMode.INJECTION_SETUP_BEAM,
+			LHCBeamMode.INJECTION_PHYSICS_BEAM,
+			LHCBeamMode.PREPARE_RAMP,
+			LHCBeamMode.RAMP,
+			LHCBeamMode.FLAT_TOP,
+			LHCBeamMode.SQUEEZE,
+			LHCBeamMode.ADJUST,
+			LHCBeamMode.STABLE_BEAMS
+		}));
+
+		Map<String, Boolean> results = new HashMap<String, Boolean>();
+
+		BeamActive instance = new BeamActive();
+
+		// check all modes
+		for (LHCBeamMode mode : LHCBeamMode.values()) {
+
+			String modeName = mode.getCode();
+			snapshot.setLhcBeamMode(modeName);
+
+			boolean expectedResult = activeModeSet.contains(mode);
+
+			boolean result = instance.satisfied(snapshot, results);
+
+			assertEquals("unexpected result for beam mode " + modeName, expectedResult, result);
+
+		} // loop over LHC modes
+		
+	}
+
+}


### PR DESCRIPTION
added missing strings for the `code` field in class `LHCBeamMode` (as discussed with @gladky).

Also added a test for class `BeamActive` whose behaviour will effectively change and do what the code actually intends to do (before it was returning `true` only for `STABLE BEAMS`).
