### PR TITLE
moved hamcrest dependency higher up 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,19 @@
 			<version>1.2.17</version>
 		</dependency>
 
+                <dependency>
+			<groupId>org.hamcrest</groupId>
+			<artifactId>hamcrest-core</artifactId>
+			<version>1.3</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.hamcrest</groupId>
+			<artifactId>hamcrest-library</artifactId>
+			<version>1.3</version>
+			<scope>test</scope>
+		</dependency>
+
 		<dependency>
 			<groupId>ch.cern</groupId>
 			<artifactId>DAQAggregator</artifactId>
@@ -185,19 +198,6 @@
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-core</artifactId>
 			<version>1.9.5</version>
-			<scope>test</scope>
-		</dependency>
-
-		<dependency>
-			<groupId>org.hamcrest</groupId>
-			<artifactId>hamcrest-core</artifactId>
-			<version>1.3</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.hamcrest</groupId>
-			<artifactId>hamcrest-library</artifactId>
-			<version>1.3</version>
 			<scope>test</scope>
 		</dependency>
 


### PR DESCRIPTION
moved hamcrest dependency immediately before DAQAggregator dependency) as suggested in https://stackoverflow.com/a/7878281/288875 , to avoid java.lang.NoSuchMethodError with hamcrest when running unit tests.