### PR TITLE
hotfix: adjustable zero rate threshold

### DIFF
--- a/src/main/java/rcms/utilities/daqexpert/Setting.java
+++ b/src/main/java/rcms/utilities/daqexpert/Setting.java
@@ -22,6 +22,8 @@ public enum Setting {
 	EXPERT_LOGIC_DEADTIME_THESHOLD_TTS("expert.logic.deadtime.threshold.tts"),
 	EXPERT_LOGIC_DEADTIME_THESHOLD_RETRI("expert.logic.deadtime.threshold.retri"),
 
+	EXPERT_LOGIC_NO_TRIGGER_RATE_THRESHOLD("expert.logic.norate.threshold"),
+	
 	EXPERT_LOGIC_CONTINOUSSOFTERROR_THESHOLD_COUNT("expert.logic.continoussofterror.threshold.count"),
 	EXPERT_LOGIC_CONTINOUSSOFTERROR_THESHOLD_PERIOD("expert.logic.continoussofterror.threshold.period"),
 	EXPERT_LOGIC_CONTINOUSSOFTERROR_THESHOLD_KEEP("expert.logic.continoussofterror.threshold.keep"),

--- a/src/main/java/rcms/utilities/daqexpert/reasoning/logic/basic/NoRate.java
+++ b/src/main/java/rcms/utilities/daqexpert/reasoning/logic/basic/NoRate.java
@@ -1,9 +1,13 @@
 package rcms.utilities.daqexpert.reasoning.logic.basic;
 
 import java.util.Map;
+import java.util.Properties;
 
 import rcms.utilities.daqaggregator.data.DAQ;
 import rcms.utilities.daqexpert.reasoning.base.ActionLogicModule;
+import rcms.utilities.daqexpert.ExpertException;
+import rcms.utilities.daqexpert.ExpertExceptionCode;
+import rcms.utilities.daqexpert.Setting;
 import rcms.utilities.daqexpert.reasoning.base.SimpleLogicModule;
 import rcms.utilities.daqexpert.reasoning.base.enums.ConditionGroup;
 import rcms.utilities.daqexpert.reasoning.base.enums.ConditionPriority;
@@ -11,8 +15,16 @@ import rcms.utilities.daqexpert.reasoning.base.enums.ConditionPriority;
 /**
  * This logic module identifies no rate condition in DAQ
  */
-public class NoRate extends SimpleLogicModule {
+public class NoRate extends SimpleLogicModule implements Parameterizable {
 
+	/** The threshold below which the trigger rate is considered as zero.
+	 *  With normal running conditions this value should be set to zero
+	 *  but are special running conditions (such as splashes) when
+	 *  even periodic calibration triggers are disabled and zero trigger
+	 *  rate is not necessarily an indication of a problem with data taking. 
+	 */
+	private float threshold;
+	
 	public NoRate() {
 		this.name = "No rate";
 		this.priority = ConditionPriority.DEFAULTT;
@@ -24,10 +36,25 @@ public class NoRate extends SimpleLogicModule {
 	 */
 	@Override
 	public boolean satisfied(DAQ daq, Map<String, Boolean> results) {
-		if (daq.getFedBuilderSummary().getRate() == 0)
+		if (daq.getFedBuilderSummary().getRate() <= threshold)
 			return true;
 		else
 			return false;
+	}
+
+	@Override
+	public void parametrize(Properties properties) {
+		try {
+			this.threshold = Integer
+					.parseInt(properties.getProperty(Setting.EXPERT_LOGIC_NO_TRIGGER_RATE_THRESHOLD.getKey()));
+
+		} catch (NumberFormatException e) {
+			throw new ExpertException(ExpertExceptionCode.LogicModuleUpdateException, "Could not update LM "
+					+ this.getClass().getSimpleName() + ", number parsing problem: " + e.getMessage());
+		} catch (NullPointerException e) {
+			throw new ExpertException(ExpertExceptionCode.LogicModuleUpdateException,
+					"Could not update LM " + this.getClass().getSimpleName() + ", other problem: " + e.getMessage());
+		}
 	}
 
 }

--- a/src/main/java/rcms/utilities/daqexpert/reasoning/logic/basic/NoRate.java
+++ b/src/main/java/rcms/utilities/daqexpert/reasoning/logic/basic/NoRate.java
@@ -4,12 +4,10 @@ import java.util.Map;
 import java.util.Properties;
 
 import rcms.utilities.daqaggregator.data.DAQ;
-import rcms.utilities.daqexpert.reasoning.base.ActionLogicModule;
 import rcms.utilities.daqexpert.ExpertException;
 import rcms.utilities.daqexpert.ExpertExceptionCode;
 import rcms.utilities.daqexpert.Setting;
 import rcms.utilities.daqexpert.reasoning.base.SimpleLogicModule;
-import rcms.utilities.daqexpert.reasoning.base.enums.ConditionGroup;
 import rcms.utilities.daqexpert.reasoning.base.enums.ConditionPriority;
 
 /**

--- a/src/test/resources/integration.properties
+++ b/src/test/resources/integration.properties
@@ -64,6 +64,8 @@ expert.logic.lenghtyfixingsofterror.threshold.period = 30000
 expert.logic.cloudfunumber.threshold.total.fraction = 0.03
 expert.logic.cloudfunumber.holdoff.period = 1800000
 
+expert.logic.norate.threshold = 0
+
 # Experimental mode
 experimental=/home/mgladki/experimental/
 


### PR DESCRIPTION
This hotfix makes the definition of 'zero rate' configurable, as discussed in #171 .